### PR TITLE
v0.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'pip' 
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install ".[test]"
 
       - name: Build wheels
         run: python -m cibuildwheel

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub: acl-cpp-python](https://img.shields.io/badge/GitHub-acl--cpp--python-darkmagenta?logo=GitHub&logoColor=white)](https://github.com/tatyam-prime/acl-cpp-python)
 [![PyPI: acl-cpp-python](https://img.shields.io/badge/PyPI-acl--cpp--python-006dad?logo=PyPI&logoColor=white)](https://pypi.org/project/acl-cpp-python/)
-[![AC Library: v1.5.1](https://img.shields.io/badge/AC%20Library-v1.5.1-seagreen)](https://github.com/atcoder/ac-library) [![License: CC0 1.0](https://img.shields.io/badge/License-CC0%201.0-darkgoldenrod)](https://creativecommons.org/publicdomain/zero/1.0/)
+[![AC Library: v1.6](https://img.shields.io/badge/AC%20Library-v1.6-seagreen)](https://github.com/atcoder/ac-library) [![License: CC0 1.0](https://img.shields.io/badge/License-CC0%201.0-darkgoldenrod)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 Documentation: [日本語](https://tatyam-prime.github.io/acl-cpp-python/ja/) | [English](https://tatyam-prime.github.io/acl-cpp-python/en/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 [![GitHub: acl-cpp-python](https://img.shields.io/badge/GitHub-acl--cpp--python-darkmagenta?logo=GitHub&logoColor=white)](https://github.com/tatyam-prime/acl-cpp-python)
 [![PyPI: acl-cpp-python](https://img.shields.io/badge/PyPI-acl--cpp--python-006dad?logo=PyPI&logoColor=white)](https://pypi.org/project/acl-cpp-python/)
-[![AC Library: v1.5.1](https://img.shields.io/badge/AC%20Library-v1.5.1-seagreen)](https://github.com/atcoder/ac-library) [![License: CC0 1.0](https://img.shields.io/badge/License-CC0%201.0-darkgoldenrod)](https://creativecommons.org/publicdomain/zero/1.0/)
+[![AC Library: v1.6](https://img.shields.io/badge/AC%20Library-v1.6-seagreen)](https://github.com/atcoder/ac-library) [![License: CC0 1.0](https://img.shields.io/badge/License-CC0%201.0-darkgoldenrod)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 日本語 | <a href="../en/">English</a>
 

--- a/docs/locale/en/LC_MESSAGES/index.po
+++ b/docs/locale/en/LC_MESSAGES/index.po
@@ -28,7 +28,7 @@ msgid ""
 "python](https://img.shields.io/badge/PyPI-acl--cpp--python-"
 "006dad?logo=PyPI&logoColor=white)](https://pypi.org/project/acl-cpp-"
 "python/) [![AC Library: "
-"v1.5.1](https://img.shields.io/badge/AC%20Library-v1.5.1-seagreen)](https://github.com/atcoder"
+"v1.6](https://img.shields.io/badge/AC%20Library-v1.6-seagreen)](https://github.com/atcoder"
 "/ac-library) [![License: CC0 1.0](https://img.shields.io/badge/License-"
 "CC0%201.0-darkgoldenrod)](https://creativecommons.org/publicdomain/zero/1.0/)"
 msgstr ""
@@ -42,7 +42,7 @@ msgid "PyPI: acl-cpp-python"
 msgstr ""
 
 #: ../../index.md:3
-msgid "AC Library: v1.5.1"
+msgid "AC Library: v1.6"
 msgstr ""
 
 #: ../../index.md:3

--- a/docs/string.md
+++ b/docs/string.md
@@ -116,6 +116,6 @@ n = len(s)
 sa = suffix_array(s)
 lcp = lcp_array(s, sa)
 
-print(n * (n + 1) // 2 - sum(lcp))
+print(n * (n - 1) // 2 - sum(lcp))
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "scikit-build-core ~= 0.10.7", 
-    "nanobind ~= 2.2.0"
+    "scikit-build-core ~= 0.11.2", 
+    "nanobind ~= 2.7.0"
 ]
 build-backend = "scikit_build_core.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "acl-cpp-python"
-version = "0.6.1"
+version = "0.6.2"
 readme = "README.md"
 description = "Python bindings for the AtCoder Library"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ build = [
 ]
 
 [tool.cibuildwheel]
-build = ["cp3{9,13}-*", "pp3{9,10}-*"]
+build = ["cp3{9,13}-*", "pp3{9,11}-*"]
 archs = ["auto64"]
 test-requires = "pytest"
 test-command = "pytest {project}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
   "myst-parser ~= 4.0.0",
 ]
 test = [
-  "cibuildwheel ~= 2.22.0",
+  "cibuildwheel ~= 2.23.3",
   "pytest ~= 8.3.4",
 ]
 build = [

--- a/src/convolution.hpp
+++ b/src/convolution.hpp
@@ -192,8 +192,8 @@ void butterfly_inv(std::vector<mint>& a) {
                     auto r = a[i + offset + p];
                     a[i + offset] = l + r;
                     a[i + offset + p] =
-                        (unsigned long long)(mint::mod() + l.val() - r.val()) * irot.val();
-                    ;
+                        (unsigned long long)((unsigned int)(l.val() - r.val()) + mint::mod()) *
+                        irot.val();
                 }
                 if (s + 1 != (1 << (len - 1)))
                     irot *= info.irate2[countr_zero(~(unsigned int)(s))];

--- a/src/dsu.hpp
+++ b/src/dsu.hpp
@@ -37,8 +37,7 @@ struct dsu {
 
     int leader(int a) {
         assert(0 <= a && a < _n);
-        if (parent_or_size[a] < 0) return a;
-        return parent_or_size[a] = leader(parent_or_size[a]);
+        return _leader(a);
     }
 
     int size(int a) {
@@ -71,6 +70,11 @@ struct dsu {
     // root node: -1 * component size
     // otherwise: parent
     std::vector<int> parent_or_size;
+
+    int _leader(int a) {
+        if (parent_or_size[a] < 0) return a;
+        return parent_or_size[a] = _leader(parent_or_size[a]);
+    }
 };
 
 }  // namespace atcoder

--- a/src/modint.hpp
+++ b/src/modint.hpp
@@ -48,7 +48,7 @@ struct static_modint : internal::static_modint_base {
         _v = (unsigned int)(v % umod());
     }
 
-    unsigned int val() const { return _v; }
+    int val() const { return _v; }
 
     mint& operator++() {
         _v++;
@@ -183,7 +183,7 @@ template <int id> struct dynamic_modint : internal::modint_base {
         _v = (unsigned int)(v % mod());
     }
 
-    unsigned int val() const { return _v; }
+    int val() const { return _v; }
 
     mint& operator++() {
         _v++;


### PR DESCRIPTION
- ac-library の v1.6 に追従 (`dsu::merge` がわずかに高速化)
- `AC code of <https://atcoder.jp/contests/practice2/tasks/practice2_i>` が間違ってた
- scikit-build-core のアップデート (PyPy 3.11 に対応)